### PR TITLE
Add an option to use `tensorflow_text.utf8_binarize` whenever available

### DIFF
--- a/retvec/tf/binarizers.py
+++ b/retvec/tf/binarizers.py
@@ -14,12 +14,36 @@
  limitations under the License.
  """
 
+import logging
+import re
 from typing import Any, Dict, List, Optional, Union
 
 import tensorflow as tf
 from tensorflow import Tensor, TensorShape
 
+try:
+    from tensorflow_text import utf8_binarize
+except ImportError:
+    utf8_binarize = None
+
 from .integerizers import RetVecIntegerizer
+
+
+def _reshape_embeddings(embeddings: tf.Tensor, batch_size: int, max_words: int,
+                        max_chars: int, encoding_size: int) -> tf.Tensor:
+    if max_words > 1:
+        return tf.reshape(
+            embeddings,
+            (
+                batch_size,
+                max_words,
+                max_chars,
+                encoding_size,
+            ),
+        )
+    else:
+        return tf.reshape(embeddings,
+                          (batch_size, max_chars, encoding_size))
 
 
 @tf.keras.utils.register_keras_serializable(package="tensorflow_retvec")
@@ -61,21 +85,10 @@ class RetVecIntBinarizer(tf.keras.layers.Layer):
         embeddings = tf.cast(embeddings, dtype="float32")
 
         # reshape back to correct shape
-        if self.max_words > 1:
-            embeddings = tf.reshape(
-                embeddings,
-                (
-                    batch_size,
-                    self.max_words,
-                    self.max_chars,
-                    self.encoding_size,
-                ),
-            )
-        else:
-            embeddings = tf.reshape(embeddings, (batch_size, self.max_chars,
-                                                 self.encoding_size))
-
-        return embeddings
+        return _reshape_embeddings(embeddings, batch_size=batch_size,
+                                   max_words=self.max_words,
+                                   max_chars=self.max_chars,
+                                   encoding_size=self.encoding_size)
 
     def _project(self, chars: Tensor, masks: Tensor) -> Tensor:
         """Project chars in subspace"""
@@ -115,6 +128,7 @@ class RetVecBinarizer(tf.keras.layers.Layer):
         encoding_type: str = "UTF-8",
         cls_int: Optional[int] = None,
         replacement_int: int = 11,
+        allow_native: bool = False,
         **kwargs
     ) -> None:
         """Initialize a RetVec binarizer.
@@ -124,7 +138,7 @@ class RetVecBinarizer(tf.keras.layers.Layer):
                 is 2d, i.e. (batch_size, num_words) this is still the max
                 characters per word.
 
-            encoding_size: Size of output character encoding.
+            encoding_size: Size of output character encoding (in bits).
 
             encoding_type: String name for the unicode encoding that should
                 be used to decode each string.
@@ -133,6 +147,10 @@ class RetVecBinarizer(tf.keras.layers.Layer):
 
             replacement_int: The replacement integer to be used in place
                 of invalid characters in input.
+
+            allow_native: A boolean indicating whether to use
+                `tensorflow_text.utf8_binarize` whenever possible
+                (limited by its availability and constraints).
 
             **kwargs: Keyword args passed to the base Layer class.
         """
@@ -144,9 +162,20 @@ class RetVecBinarizer(tf.keras.layers.Layer):
         self.cls_int = cls_int
         self.replacement_int = replacement_int
 
+        # Check if the native `utf8_binarize` op is available for use.
+        is_utf8_encoding = re.match('^utf-?8$', encoding_type, re.IGNORECASE)
+        self._native_mode = (allow_native and
+                             is_utf8_encoding and
+                             utf8_binarize is not None and
+                             cls_int is None)
+        if allow_native and not self._native_mode:
+            logging.warning('Native support for `RetVecBinarizer` unavailable. '
+                            'Check `tensorflow_text.utf8_binarize` availability'
+                            ' and its parameter contraints.')
+
         # Set to True when 'binarize()' is called in eager mode
         self.eager = False
-        self._integerizer = RetVecIntegerizer(
+        self._integerizer = None if self._native_mode else RetVecIntegerizer(
             max_chars=self.max_chars,
             encoding_type=self.encoding_type,
             cls_int=self.cls_int,
@@ -157,16 +186,27 @@ class RetVecBinarizer(tf.keras.layers.Layer):
         self.max_words = input_shape[-1] if len(input_shape) > 1 else 1
 
         # Initialize int binarizer layer here since we know max_words
-        self._int_binarizer = RetVecIntBinarizer(
+        self._int_binarizer = None if self._native_mode else RetVecIntBinarizer(
             max_chars=self.max_chars,
             max_words=self.max_words,
             encoding_size=self.encoding_size,
         )
 
     def call(self, inputs: Tensor) -> Tensor:
-        char_encodings = self._integerizer(inputs)
-        embeddings = self._int_binarizer(char_encodings)
-        return embeddings
+        if self._native_mode:
+            embeddings = utf8_binarize(inputs,
+                                       word_length=self.max_chars,
+                                       bits_per_char=self.encoding_size,
+                                       replacement_char=self.replacement_int)
+            batch_size = tf.shape(inputs)[0]
+            return _reshape_embeddings(embeddings, batch_size=batsh_size,
+                                       max_words=self.max_words,
+                                       max_chars=self.max_chars,
+                                       encoding_size=self.encoding_size)
+        else:
+            char_encodings = self._integerizer(inputs)
+            embeddings = self._int_binarizer(char_encodings)
+            return embeddings
 
     def binarize(self, words: Tensor) -> Tensor:
         """Return RetVec binarizer encodings for a word or a list of words.
@@ -184,7 +224,8 @@ class RetVecBinarizer(tf.keras.layers.Layer):
 
         # set layers to eager mode
         self.eager = True
-        self._integerizer.eager = True
+        if self._integerizer is not None:
+            self._integerizer.eager = True
 
         # apply binarization
         embeddings = self(inputs)
@@ -205,6 +246,7 @@ class RetVecBinarizer(tf.keras.layers.Layer):
                 "encoding_type": self.encoding_type,
                 "cls_int": self.cls_int,
                 "replacement_int": self.replacement_int,
+                "allow_native": self.allow_native,
             }
         )
         return config

--- a/retvec/tf/retvec.py
+++ b/retvec/tf/retvec.py
@@ -40,6 +40,7 @@ class RetVec(tf.keras.layers.Layer):
         char_encoding_type: str = "UTF-8",
         cls_int: Optional[int] = None,
         replacement_int: int = 11,
+        allow_native_binarizer: bool = False,
         dropout_rate: float = 0.0,
         spatial_dropout_rate: float = 0.0,
         norm_type: Optional[str] = None,
@@ -72,6 +73,9 @@ class RetVec(tf.keras.layers.Layer):
 
             replacement_int: The replacement integer to be used in place
                 of invalid characters in input.
+
+            allow_native_binarizer: Allow using the TF Text binarizer
+                implementation if available.
 
             dropout_rate: Dropout to apply after RetVec embedding.
 
@@ -108,6 +112,7 @@ class RetVec(tf.keras.layers.Layer):
             encoding_type=self.char_encoding_type,
             cls_int=self.cls_int,
             replacement_int=self.replacement_int,
+            allow_native=allow_native_binarizer,
         )
 
         # Set to True when 'tokenize()' or 'binarize()' called in eager mode

--- a/tests/tf/models/test_rewnet.py
+++ b/tests/tf/models/test_rewnet.py
@@ -18,8 +18,8 @@ import pytest
 import tensorflow as tf
 from tensorflow_similarity.losses import MultiSimilarityLoss
 
-from tensorflow_retvec import RetVec
-from tensorflow_retvec.rewnet import REWCNN, REWformer
+from retvec.tf.retvec import RetVec
+from retvec.tf.models import REWCNN, REWformer
 
 tf.config.set_visible_devices([], "GPU")
 

--- a/tests/tf/test_binarizers.py
+++ b/tests/tf/test_binarizers.py
@@ -14,14 +14,15 @@
  limitations under the License.
  """
 
+import pytest
 import tensorflow as tf
 
-from tensorflow_retvec import RetVecBinarizer
+from retvec.tf.retvec import RetVecBinarizer
 
 
 def test_graph_mode():
     i = tf.keras.layers.Input((1,), dtype=tf.string)
-    x = RetVecBinarizer(max_chars=16, encoding_size=32)(i)
+    x = RetVecBinarizer(max_chars=16, encoding_size=32, allow_native=True)(i)
     model = tf.keras.models.Model(i, x)
 
     test_inputs = [
@@ -36,7 +37,8 @@ def test_graph_mode():
 
 
 def test_eager_mode():
-    binarizer = RetVecBinarizer(max_chars=16, encoding_size=32)
+    binarizer = RetVecBinarizer(
+            max_chars=16, encoding_size=32, allow_native=True)
 
     s = "Testing😀"
 
@@ -49,7 +51,7 @@ def test_eager_mode():
 
 def test_2d_inputs():
     i = tf.keras.layers.Input((2,), dtype=tf.string)
-    x = RetVecBinarizer(max_chars=16, encoding_size=32)(i)
+    x = RetVecBinarizer(max_chars=16, encoding_size=32, allow_native=True)(i)
     model = tf.keras.models.Model(i, x)
 
     test_input = tf.constant([["a", "b"], ["c", "d"]])
@@ -77,7 +79,8 @@ def test_tfds_map():
 
 
 def test_determinism_eager_mode():
-    binarizer = RetVecBinarizer(max_chars=16, encoding_size=32)
+    binarizer = RetVecBinarizer(
+            max_chars=16, encoding_size=32, allow_native=True)
 
     s = "Testing😀"
     test_input = tf.constant([s, s])
@@ -91,7 +94,7 @@ def test_determinism_eager_mode():
 
 def test_determinism_graph_mode():
     i = tf.keras.layers.Input((1,), dtype=tf.string)
-    x = RetVecBinarizer(max_chars=16, encoding_size=32)(i)
+    x = RetVecBinarizer(max_chars=16, encoding_size=32, allow_native=True)(i)
     model = tf.keras.models.Model(i, x)
 
     s = "Testing😀"
@@ -106,7 +109,7 @@ def test_determinism_graph_mode():
 
 def test_serialization(tmp_path):
     i = tf.keras.layers.Input((1,), dtype=tf.string)
-    x = RetVecBinarizer(max_chars=16, encoding_size=32)(i)
+    x = RetVecBinarizer(max_chars=16, encoding_size=32, allow_native=True)(i)
     model = tf.keras.models.Model(i, x)
 
     save_path = tmp_path / "test_serialization_binarizer"
@@ -129,8 +132,49 @@ def test_common_parameters():
                             encoding_type=encoding_type,
                             cls_int=cls_int,
                             replacement_int=replacement_int,
+                            allow_native=False,
                         )(i)
                         model = tf.keras.models.Model(i, x)
 
                         embedding = model(test_input)
                         assert embedding.shape == (2, max_chars, encoding_size)
+
+
+def test_common_parameters_native():
+    try:
+        from tensorflow_text import utf8_binarize
+    except ImportError:
+        pytest.skip("No `utf8_binarize` implementation available")
+
+    test_input = tf.constant(["Testing😀", "Testing😀"])
+
+    for max_chars in [8, 16, 32]:
+        for encoding_size in [16, 32]:
+            for replacement_int in [0, 65533]:
+                i = tf.keras.layers.Input((1,), dtype=tf.string)
+                x = RetVecBinarizer(
+                    max_chars=max_chars,
+                    encoding_size=encoding_size,
+                    encoding_type="UTF-8",
+                    cls_int=None,
+                    replacement_int=replacement_int,
+                    allow_native=False,
+                )(i)
+                model = tf.keras.models.Model(i, x)
+
+                embedding = model(test_input)
+                assert embedding.shape == (2, max_chars, encoding_size)
+
+                x = RetVecBinarizer(
+                    max_chars=max_chars,
+                    encoding_size=encoding_size,
+                    encoding_type="UTF-8",
+                    cls_int=cls_int,
+                    replacement_int=replacement_int,
+                    allow_native=True,
+                )(i)
+                model = tf.keras.models.Model(i, x)
+
+                embedding_native = model(test_input)
+                assert (embedding.numpy().tolist() ==
+                        embedding_native.numpy().tolist())

--- a/tests/tf/test_embedding.py
+++ b/tests/tf/test_embedding.py
@@ -16,7 +16,7 @@
 
 import tensorflow as tf
 
-from tensorflow_retvec import RetVecBinarizer, RetVecEmbedding
+from retvec.tf.retvec import RetVecBinarizer, RetVecEmbedding
 
 TEST_EMB_SIZE = 16
 

--- a/tests/tf/test_integerizers.py
+++ b/tests/tf/test_integerizers.py
@@ -16,7 +16,7 @@
 
 import tensorflow as tf
 
-from tensorflow_retvec import RetVecIntegerizer
+from retvec.tf.integerizers import RetVecIntegerizer
 
 
 def test_graph_mode():

--- a/tests/tf/test_retvec.py
+++ b/tests/tf/test_retvec.py
@@ -16,7 +16,7 @@
 
 import tensorflow as tf
 
-from tensorflow_retvec import RetVec
+from retvec.tf.retvec import RetVec
 
 MAX_LEN = 128
 MAX_CHARS = 16


### PR DESCRIPTION
This option allows to use the native (and TF Lite-compatible) `tensorflow_text.utf8_binarize` op (considered for addition to TensorFlow Text) when it is available and its constraints are satisfied (source encoding is UTF-8 and replacement is encoded as all ones).

Note that the default combination of parameters currently doesn't satisfy these limitations.