### PR TITLE
Add an option to use `tensorflow_text.utf8_binarize` whenever available

### DIFF
--- a/retvec/tf/layers/binarizers.py
+++ b/retvec/tf/layers/binarizers.py
@@ -14,12 +14,37 @@
  limitations under the License.
  """
 
+import logging
+import re
 from typing import Any, Dict, List, Optional, Union
 
 import tensorflow as tf
 from tensorflow import Tensor, TensorShape
 
+try:
+    from tensorflow_text import utf8_binarize
+except ImportError:
+    utf8_binarize = None
+
 from .integerizers import RetVecIntegerizer
+
+
+def _reshape_embeddings(embeddings: tf.Tensor, batch_size: int,
+                        sequence_length: int, word_length: int,
+                        encoding_size: int) -> tf.Tensor:
+    if sequence_length > 1:
+        return tf.reshape(
+            embeddings,
+            (
+                batch_size,
+                sequence_length,
+                word_length,
+                encoding_size,
+            ),
+        )
+    else:
+        return tf.reshape(embeddings,
+                          (batch_size, word_length, encoding_size))
 
 
 @tf.keras.utils.register_keras_serializable(package="retvec")
@@ -71,20 +96,10 @@ class RetVecIntToBinary(tf.keras.layers.Layer):
         embeddings = tf.cast(embeddings, dtype="float32")
 
         # reshape back to correct shape
-        if self.sequence_length > 1:
-            embeddings = tf.reshape(
-                embeddings,
-                (
-                    batch_size,
-                    self.sequence_length,
-                    self.word_length,
-                    self.encoding_size,
-                ),
-            )
-        else:
-            embeddings = tf.reshape(embeddings, (batch_size, self.word_length, self.encoding_size))
-
-        return embeddings
+        return _reshape_embeddings(embeddings, batch_size=batch_size,
+                                   sequence_length=self.sequence_length,
+                                   word_length=self.word_length,
+                                   encoding_size=self.encoding_size)
 
     def _project(self, chars: Tensor, masks: Tensor) -> Tensor:
         """Project chars in subspace"""
@@ -124,6 +139,7 @@ class RetVecBinarizer(tf.keras.layers.Layer):
         encoding_type: str = "UTF-8",
         cls_int: Optional[int] = None,
         replacement_int: int = 11,
+        allow_native: bool = False,
         **kwargs
     ) -> None:
         """Initialize a RetVec binarizer.
@@ -133,7 +149,7 @@ class RetVecBinarizer(tf.keras.layers.Layer):
                 is 2d, i.e. (batch_size, num_words) this is still the max
                 characters per word.
 
-            encoding_size: Size of output character encoding.
+            encoding_size: Size of output character encoding (in bits).
 
             encoding_type: String name for the unicode encoding that should
                 be used to decode each string.
@@ -142,6 +158,10 @@ class RetVecBinarizer(tf.keras.layers.Layer):
 
             replacement_int: The replacement integer to be used in place
                 of invalid characters in input.
+
+            allow_native: A boolean indicating whether to use
+                `tensorflow_text.utf8_binarize` whenever possible
+                (limited by its availability and constraints).
 
             **kwargs: Keyword args passed to the base Layer class.
         """
@@ -152,10 +172,22 @@ class RetVecBinarizer(tf.keras.layers.Layer):
         self.encoding_type = encoding_type
         self.cls_int = cls_int
         self.replacement_int = replacement_int
+        self.allow_native = allow_native
+
+        # Check if the native `utf8_binarize` op is available for use.
+        is_utf8_encoding = re.match('^utf-?8$', encoding_type, re.IGNORECASE)
+        self._native_mode = (allow_native and
+                             is_utf8_encoding and
+                             utf8_binarize is not None and
+                             cls_int is None)
+        if allow_native and not self._native_mode:
+            logging.warning('Native support for `RetVecBinarizer` unavailable. '
+                            'Check `tensorflow_text.utf8_binarize` availability'
+                            ' and its parameter contraints.')
 
         # Set to True when 'binarize()' is called in eager mode
         self.eager = False
-        self._integerizer = RetVecIntegerizer(
+        self._integerizer = None if self._native_mode else RetVecIntegerizer(
             max_chars=self.max_chars,
             encoding_type=self.encoding_type,
             cls_int=self.cls_int,
@@ -166,16 +198,29 @@ class RetVecBinarizer(tf.keras.layers.Layer):
         self.max_words = input_shape[-1] if len(input_shape) > 1 else 1
 
         # Initialize int binarizer layer here since we know max_words
-        self._int_binarizer = RetVecIntToBinary(
+        self._int_binarizer = None if self._native_mode else RetVecIntToBinary(
             word_length=self.max_chars,
             sequence_length=self.max_words,
             encoding_size=self.encoding_size,
         )
 
     def call(self, inputs: Tensor) -> Tensor:
-        char_encodings = self._integerizer(inputs)
-        embeddings = self._int_binarizer(char_encodings)
-        return embeddings
+        if self._native_mode:
+            embeddings = utf8_binarize(inputs,
+                                       word_length=self.max_chars,
+                                       bits_per_char=self.encoding_size,
+                                       replacement_char=self.replacement_int)
+            batch_size = tf.shape(inputs)[0]
+            return _reshape_embeddings(embeddings, batch_size=batch_size,
+                                       sequence_length=self.max_words,
+                                       word_length=self.max_chars,
+                                       encoding_size=self.encoding_size)
+        else:
+            assert self._integerizer is not None
+            char_encodings = self._integerizer(inputs)
+            assert self._int_binarizer is not None
+            embeddings = self._int_binarizer(char_encodings)
+            return embeddings
 
     def binarize(self, words: Tensor) -> Tensor:
         """Return RetVec binarizer encodings for a word or a list of words.
@@ -193,7 +238,8 @@ class RetVecBinarizer(tf.keras.layers.Layer):
 
         # set layers to eager mode
         self.eager = True
-        self._integerizer.eager = True
+        if self._integerizer is not None:
+            self._integerizer.eager = True
 
         # apply binarization
         embeddings = self(inputs)
@@ -213,6 +259,7 @@ class RetVecBinarizer(tf.keras.layers.Layer):
                 "encoding_type": self.encoding_type,
                 "cls_int": self.cls_int,
                 "replacement_int": self.replacement_int,
+                "allow_native": self.allow_native,
             }
         )
         return config

--- a/retvec/tf/layers/retvec.py
+++ b/retvec/tf/layers/retvec.py
@@ -40,6 +40,7 @@ class RetVec(tf.keras.layers.Layer):
         char_encoding_type: str = "UTF-8",
         cls_int: Optional[int] = None,
         replacement_int: int = 11,
+        allow_native_binarizer: bool = False,
         dropout_rate: float = 0.0,
         spatial_dropout_rate: float = 0.0,
         norm_type: Optional[str] = None,
@@ -72,6 +73,9 @@ class RetVec(tf.keras.layers.Layer):
 
             replacement_int: The replacement integer to be used in place
                 of invalid characters in input.
+
+            allow_native_binarizer: Allow using the TF Text binarizer
+                implementation if available.
 
             dropout_rate: Dropout to apply after RetVec embedding.
 
@@ -108,6 +112,7 @@ class RetVec(tf.keras.layers.Layer):
             encoding_type=self.char_encoding_type,
             cls_int=self.cls_int,
             replacement_int=self.replacement_int,
+            allow_native=allow_native_binarizer,
         )
 
         # Set to True when 'tokenize()' or 'binarize()' called in eager mode


### PR DESCRIPTION
This option allows to use the native (and TF Lite-compatible) `tensorflow_text.utf8_binarize` op (considered for addition to TensorFlow Text) when it is available and its constraints are satisfied (source encoding is UTF-8 and no CLS token is specified).